### PR TITLE
:wheelchair: Focus on the first tile

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -56,3 +56,8 @@ gridItems.forEach((gridItem, index) => {
     }
   });
 });
+
+
+// placing cursor at the first tile when the page loads
+gridItems[0].focus();
+


### PR DESCRIPTION
Closes #1 

User is able to start the game with the cursor automatically focused on the first tile when the page loads